### PR TITLE
symfony6.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "ptachoire/php-dmtx",
     "description": "Datamatrix r/w based on libdmtx <http://www.libdmtx.org/>",
     "require": {
-        "symfony/process": "~3.4||~4.0||~5.0",
-        "symfony/options-resolver": "~3.4||~4.0||~5.0"
+        "symfony/process": "~3.4||~4.0||~5.0||~6.0",
+        "symfony/options-resolver": "~3.4||~4.0||~5.0||~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-0": { "Dmtx": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-    backupStaticAttributes="false"
+    backupStaticProperties="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="tests/bootstrap.php"
+    cacheDirectory=".phpunit.cache"
     >
     <testsuites>
         <testsuite name="Dmtx Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/Dmtx/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/Dmtx/Tests/ReaderTest.php
+++ b/tests/Dmtx/Tests/ReaderTest.php
@@ -16,7 +16,7 @@ class ReaderTest extends TestCase
         $this->reader = new Reader($this->options ?? []);
     }
 
-    public function imageTestProvider()
+    public static function imageTestProvider()
     {
         return [
             'simpleMessageShouldBeValid' => [

--- a/tests/Dmtx/Tests/WriterTest.php
+++ b/tests/Dmtx/Tests/WriterTest.php
@@ -45,7 +45,7 @@ class WriterTest extends TestCase
         );
     }
 
-    public function imageTestProvider()
+    public static function imageTestProvider()
     {
         return [
             'simpleMessageShouldBeValid' => [


### PR DESCRIPTION
Hi, I am using your package with php8.1&laravel8. When I tried to upgrade to laravel10, it conflicts with php-dmtx.
The PR is to update to package to support php8.1 and symfony, which also needs to upgrade phpunit.
My local test passed, see below.
Could you review this PR and provide a release for php8.1? Thank you!

````
bash-5.1# vendor/bin/phpunit tests
Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-(
PHPUnit 10.0.19 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.12
Configuration: /var/www/html/storage/repositories/php-dmtx2/phpunit.xml.dist

..........                                                        10 / 10 (100%)

Time: 00:01.347, Memory: 8.00 MB

OK (10 tests, 12 assertions)
````